### PR TITLE
Complete JNI fix + SIGILL handler + incompatible drivers toggle + LSFG full settings

### DIFF
--- a/app/src/main/cpp/virglrenderer/server/virgl_server.c
+++ b/app/src/main/cpp/virglrenderer/server/virgl_server.c
@@ -116,7 +116,7 @@ static void virgl_server_handle_request(struct virgl_client *client)
 }
 
 JNIEXPORT jlong JNICALL
-Java_com_winlator_xenvironment_components_VirGLRendererComponent_handleNewConnection(JNIEnv *env, jobject obj, jint fd) {
+Java_com_winlator_star_xenvironment_components_VirGLRendererComponent_handleNewConnection(JNIEnv *env, jobject obj, jint fd) {
    jni_info.env = env;
    jni_info.obj = obj;
    
@@ -129,19 +129,19 @@ Java_com_winlator_xenvironment_components_VirGLRendererComponent_handleNewConnec
 }
 
 JNIEXPORT void JNICALL
-Java_com_winlator_xenvironment_components_VirGLRendererComponent_handleRequest(JNIEnv *env, jobject obj, jlong clientPtr) {
+Java_com_winlator_star_xenvironment_components_VirGLRendererComponent_handleRequest(JNIEnv *env, jobject obj, jlong clientPtr) {
    jni_info.env = env;
    jni_info.obj = obj;
    virgl_server_handle_request((struct virgl_client*)clientPtr);
 }
 
 JNIEXPORT void JNICALL
-Java_com_winlator_xenvironment_components_VirGLRendererComponent_destroyClient(JNIEnv *env, jobject obj, jlong clientPtr) {
+Java_com_winlator_star_xenvironment_components_VirGLRendererComponent_destroyClient(JNIEnv *env, jobject obj, jlong clientPtr) {
    struct virgl_client *client = (struct virgl_client*)clientPtr;
    virgl_server_destroy_client(&client);
 }
 
 JNIEXPORT void JNICALL
-Java_com_winlator_xenvironment_components_VirGLRendererComponent_destroyRenderer(JNIEnv *env, jobject obj, jlong clientPtr) {
+Java_com_winlator_star_xenvironment_components_VirGLRendererComponent_destroyRenderer(JNIEnv *env, jobject obj, jlong clientPtr) {
    virgl_server_destroy_renderer((struct virgl_client*)clientPtr);
 }

--- a/app/src/main/cpp/virglrenderer/server/virgl_server_renderer.c
+++ b/app/src/main/cpp/virglrenderer/server/virgl_server_renderer.c
@@ -584,7 +584,7 @@ int virgl_server_renderer_create_fence(struct virgl_client *client)
 }
 
 JNIEXPORT jlong JNICALL
-Java_com_winlator_xenvironment_components_VirGLRendererComponent_getCurrentEGLContextPtr(JNIEnv *env, jobject obj) {
+Java_com_winlator_star_xenvironment_components_VirGLRendererComponent_getCurrentEGLContextPtr(JNIEnv *env, jobject obj) {
    EGLContext egl_ctx = eglGetCurrentContext();
    return egl_ctx != EGL_NO_CONTEXT ? (jlong)egl_ctx : 0;
 }

--- a/app/src/main/cpp/winlator/alsa_client.c
+++ b/app/src/main/cpp/winlator/alsa_client.c
@@ -72,13 +72,13 @@ static void aaudioFlush(AAudioStream *aaudioStream) {
 }
 
 JNIEXPORT jlong JNICALL
-Java_com_winlator_cmod_alsaserver_ALSAClient_create(JNIEnv *env, jobject obj, jint format,
+Java_com_winlator_star_alsaserver_ALSAClient_create(JNIEnv *env, jobject obj, jint format,
                                                jbyte channelCount, jint sampleRate, jint bufferSize) {
     return (jlong)aaudioCreate(format, channelCount, sampleRate, bufferSize);
 }
 
 JNIEXPORT jint JNICALL
-Java_com_winlator_cmod_alsaserver_ALSAClient_write(JNIEnv *env, jobject obj, jlong streamPtr, jobject buffer,
+Java_com_winlator_star_alsaserver_ALSAClient_write(JNIEnv *env, jobject obj, jlong streamPtr, jobject buffer,
                                               jint numFrames) {
     AAudioStream *aaudioStream = (AAudioStream*)streamPtr;
     if (aaudioStream) {
@@ -88,31 +88,31 @@ Java_com_winlator_cmod_alsaserver_ALSAClient_write(JNIEnv *env, jobject obj, jlo
 }
 
 JNIEXPORT void JNICALL
-Java_com_winlator_cmod_alsaserver_ALSAClient_start(JNIEnv *env, jobject obj, jlong streamPtr) {
+Java_com_winlator_star_alsaserver_ALSAClient_start(JNIEnv *env, jobject obj, jlong streamPtr) {
     AAudioStream *aaudioStream = (AAudioStream*)streamPtr;
     if (aaudioStream) aaudioStart(aaudioStream);
 }
 
 JNIEXPORT void JNICALL
-Java_com_winlator_cmod_alsaserver_ALSAClient_stop(JNIEnv *env, jobject obj, jlong streamPtr) {
+Java_com_winlator_star_alsaserver_ALSAClient_stop(JNIEnv *env, jobject obj, jlong streamPtr) {
     AAudioStream *aaudioStream = (AAudioStream*)streamPtr;
     if (aaudioStream) aaudioStop(aaudioStream);
 }
 
 JNIEXPORT void JNICALL
-Java_com_winlator_cmod_alsaserver_ALSAClient_pause(JNIEnv *env, jobject obj, jlong streamPtr) {
+Java_com_winlator_star_alsaserver_ALSAClient_pause(JNIEnv *env, jobject obj, jlong streamPtr) {
     AAudioStream *aaudioStream = (AAudioStream*)streamPtr;
     if (aaudioStream) aaudioPause(aaudioStream);
 }
 
 JNIEXPORT void JNICALL
-Java_com_winlator_cmod_alsaserver_ALSAClient_flush(JNIEnv *env, jobject obj, jlong streamPtr) {
+Java_com_winlator_star_alsaserver_ALSAClient_flush(JNIEnv *env, jobject obj, jlong streamPtr) {
     AAudioStream *aaudioStream = (AAudioStream*)streamPtr;
     if (aaudioStream) aaudioFlush(aaudioStream);
 }
 
 JNIEXPORT void JNICALL
-Java_com_winlator_cmod_alsaserver_ALSAClient_close(JNIEnv *env, jobject obj, jlong streamPtr) {
+Java_com_winlator_star_alsaserver_ALSAClient_close(JNIEnv *env, jobject obj, jlong streamPtr) {
     AAudioStream *aaudioStream = (AAudioStream*)streamPtr;
     if (aaudioStream) AAudioStream_close(aaudioStream);
 }

--- a/app/src/main/cpp/winlator/drawable.c
+++ b/app/src/main/cpp/winlator/drawable.c
@@ -73,7 +73,7 @@ static int setPixelOp(int srcColor, int dstColor, enum GCFunction gcFunction) {
 }
 
 JNIEXPORT void JNICALL
-Java_com_winlator_cmod_xserver_Drawable_drawBitmap(JNIEnv *env, jclass obj,
+Java_com_winlator_star_xserver_Drawable_drawBitmap(JNIEnv *env, jclass obj,
                                               jshort width, jshort height, jobject srcData,
                                               jobject dstData) {
     uint8_t *srcDataAddr = (*env)->GetDirectBufferAddress(env, srcData);
@@ -94,7 +94,7 @@ Java_com_winlator_cmod_xserver_Drawable_drawBitmap(JNIEnv *env, jclass obj,
 }
 
 JNIEXPORT void JNICALL
-Java_com_winlator_cmod_xserver_Drawable_copyArea(JNIEnv *env, jclass obj, jshort srcX,
+Java_com_winlator_star_xserver_Drawable_copyArea(JNIEnv *env, jclass obj, jshort srcX,
                                             jshort srcY, jshort dstX, jshort dstY,
                                             jshort width, jshort height, jshort srcStride,
                                             jshort dstStride, jobject srcData,
@@ -122,7 +122,7 @@ Java_com_winlator_cmod_xserver_Drawable_copyArea(JNIEnv *env, jclass obj, jshort
 }
 
 JNIEXPORT void JNICALL
-Java_com_winlator_cmod_xserver_Drawable_copyAreaOp(JNIEnv *env, jclass obj, jshort srcX,
+Java_com_winlator_star_xserver_Drawable_copyAreaOp(JNIEnv *env, jclass obj, jshort srcX,
                                               jshort srcY, jshort dstX, jshort dstY,
                                               jshort width, jshort height, jshort srcStride,
                                               jshort dstStride, jobject srcData,
@@ -152,7 +152,7 @@ Java_com_winlator_cmod_xserver_Drawable_copyAreaOp(JNIEnv *env, jclass obj, jsho
 }
 
 JNIEXPORT void JNICALL
-Java_com_winlator_cmod_xserver_Drawable_fillRect(JNIEnv *env, jclass obj, jshort x, jshort y,
+Java_com_winlator_star_xserver_Drawable_fillRect(JNIEnv *env, jclass obj, jshort x, jshort y,
                                             jshort width, jshort height, jint color, jshort stride,
                                             jobject data) {
     uint8_t *dataAddr = (*env)->GetDirectBufferAddress(env, data);
@@ -183,7 +183,7 @@ Java_com_winlator_cmod_xserver_Drawable_fillRect(JNIEnv *env, jclass obj, jshort
 }
 
 JNIEXPORT void JNICALL
-Java_com_winlator_cmod_xserver_Drawable_drawLine(JNIEnv *env, jclass obj, jshort x0, jshort y0,
+Java_com_winlator_star_xserver_Drawable_drawLine(JNIEnv *env, jclass obj, jshort x0, jshort y0,
                                             jshort x1, jshort y1, jint color, jshort lineWidth,
                                             jshort stride, jobject data) {
     uint8_t *dataAddr = (*env)->GetDirectBufferAddress(env, data);
@@ -234,7 +234,7 @@ Java_com_winlator_cmod_xserver_Drawable_drawLine(JNIEnv *env, jclass obj, jshort
 }
 
 JNIEXPORT void JNICALL
-Java_com_winlator_cmod_xserver_Drawable_drawAlphaMaskedBitmap(JNIEnv *env, jclass obj,
+Java_com_winlator_star_xserver_Drawable_drawAlphaMaskedBitmap(JNIEnv *env, jclass obj,
                                                          jbyte foreRed, jbyte foreGreen,
                                                          jbyte foreBlue, jbyte backRed,
                                                          jbyte backGreen, jbyte backBlue,
@@ -259,7 +259,7 @@ Java_com_winlator_cmod_xserver_Drawable_drawAlphaMaskedBitmap(JNIEnv *env, jclas
 }
 
 JNIEXPORT void JNICALL
-Java_com_winlator_cmod_xserver_Drawable_fromBitmap(JNIEnv *env, jclass obj, jobject bitmap,
+Java_com_winlator_star_xserver_Drawable_fromBitmap(JNIEnv *env, jclass obj, jobject bitmap,
                                               jobject data) {
     char *dataAddr = (*env)->GetDirectBufferAddress(env, data);
 
@@ -288,7 +288,7 @@ Java_com_winlator_cmod_xserver_Drawable_fromBitmap(JNIEnv *env, jclass obj, jobj
 }
 
 JNIEXPORT void JNICALL
-Java_com_winlator_cmod_xserver_Pixmap_toBitmap(JNIEnv *env, jclass obj, jobject colorData,
+Java_com_winlator_star_xserver_Pixmap_toBitmap(JNIEnv *env, jclass obj, jobject colorData,
                                           jobject maskData, jobject bitmap) {
     char *colorDataAddr = (*env)->GetDirectBufferAddress(env, colorData);
     char *maskDataAddr = maskData ? (*env)->GetDirectBufferAddress(env, maskData) : NULL;

--- a/app/src/main/cpp/winlator/gpu_image.c
+++ b/app/src/main/cpp/winlator/gpu_image.c
@@ -89,7 +89,7 @@ AHardwareBuffer* createHardwareBuffer(int width, int height) {
 
 // JNI method to extract a hardware buffer from a socketpair
 JNIEXPORT jlong JNICALL
-Java_com_winlator_cmod_renderer_GPUImage_hardwareBufferFromSocket(JNIEnv *env, jclass obj, jint fd) {
+Java_com_winlator_star_renderer_GPUImage_hardwareBufferFromSocket(JNIEnv *env, jclass obj, jint fd) {
     AHardwareBuffer *ahb;
     
     uint8_t buf = 1;
@@ -109,7 +109,7 @@ Java_com_winlator_cmod_renderer_GPUImage_hardwareBufferFromSocket(JNIEnv *env, j
 
 // JNI method to create a hardware buffer
 JNIEXPORT jlong JNICALL
-Java_com_winlator_cmod_renderer_GPUImage_createHardwareBuffer(JNIEnv *env, jclass obj, jshort width, jshort height) {
+Java_com_winlator_star_renderer_GPUImage_createHardwareBuffer(JNIEnv *env, jclass obj, jshort width, jshort height) {
     AHardwareBuffer *buffer = createHardwareBuffer(width, height);
     if (!buffer) {
         printf("Failed to create hardware buffer\n");
@@ -120,7 +120,7 @@ Java_com_winlator_cmod_renderer_GPUImage_createHardwareBuffer(JNIEnv *env, jclas
 
 // JNI method to create an EGL image
 JNIEXPORT jlong JNICALL
-Java_com_winlator_cmod_renderer_GPUImage_createImageKHR(JNIEnv *env, jclass obj, jlong hardwareBufferPtr, jint textureId) {
+Java_com_winlator_star_renderer_GPUImage_createImageKHR(JNIEnv *env, jclass obj, jlong hardwareBufferPtr, jint textureId) {
     AHardwareBuffer* hardwareBuffer = (AHardwareBuffer*)hardwareBufferPtr;
     if (!hardwareBuffer) {
         printf("Invalid AHardwareBuffer pointer\n");
@@ -131,7 +131,7 @@ Java_com_winlator_cmod_renderer_GPUImage_createImageKHR(JNIEnv *env, jclass obj,
 
 // JNI method to destroy a hardware buffer
 JNIEXPORT void JNICALL
-Java_com_winlator_cmod_renderer_GPUImage_destroyHardwareBuffer(JNIEnv *env, jclass obj, jlong hardwareBufferPtr) {
+Java_com_winlator_star_renderer_GPUImage_destroyHardwareBuffer(JNIEnv *env, jclass obj, jlong hardwareBufferPtr) {
     AHardwareBuffer* hardwareBuffer = (AHardwareBuffer*)hardwareBufferPtr;
     if (hardwareBuffer) {
         AHardwareBuffer_unlock(hardwareBuffer, NULL);
@@ -141,7 +141,7 @@ Java_com_winlator_cmod_renderer_GPUImage_destroyHardwareBuffer(JNIEnv *env, jcla
 
 // JNI method to lock a hardware buffer
 JNIEXPORT jobject JNICALL
-Java_com_winlator_cmod_renderer_GPUImage_lockHardwareBuffer(JNIEnv *env, jclass obj, jlong hardwareBufferPtr) {
+Java_com_winlator_star_renderer_GPUImage_lockHardwareBuffer(JNIEnv *env, jclass obj, jlong hardwareBufferPtr) {
     AHardwareBuffer* hardwareBuffer = (AHardwareBuffer*)hardwareBufferPtr;
     if (!hardwareBuffer) {
         printf("Invalid AHardwareBuffer pointer\n");
@@ -184,7 +184,7 @@ Java_com_winlator_cmod_renderer_GPUImage_lockHardwareBuffer(JNIEnv *env, jclass 
 
 // JNI method to destroy an EGL image
 JNIEXPORT void JNICALL
-Java_com_winlator_cmod_renderer_GPUImage_destroyImageKHR(JNIEnv *env, jclass obj, jlong imageKHRPtr) {
+Java_com_winlator_star_renderer_GPUImage_destroyImageKHR(JNIEnv *env, jclass obj, jlong imageKHRPtr) {
     EGLImageKHR imageKHR = (EGLImageKHR)imageKHRPtr;
     if (imageKHR) {
         EGLDisplay eglDisplay = eglGetDisplay(EGL_DEFAULT_DISPLAY);

--- a/app/src/main/cpp/winlator/patchelf_wrapper.cpp
+++ b/app/src/main/cpp/winlator/patchelf_wrapper.cpp
@@ -2,83 +2,83 @@
 
 extern "C"
 JNIEXPORT jlong JNICALL
-Java_com_winlator_cmod_core_PatchElf_createElfObject(JNIEnv *env, jobject thiz, jstring path) {
+Java_com_winlator_star_core_PatchElf_createElfObject(JNIEnv *env, jobject thiz, jstring path) {
     // TODO: implement createElfObject()
 }
 extern "C"
 JNIEXPORT jboolean JNICALL
-Java_com_winlator_cmod_core_PatchElf_destroyElfObject(JNIEnv *env, jobject thiz, jlong object_ptr) {
+Java_com_winlator_star_core_PatchElf_destroyElfObject(JNIEnv *env, jobject thiz, jlong object_ptr) {
     // TODO: implement destroyElfObject()
 }
 extern "C"
 JNIEXPORT jboolean JNICALL
-Java_com_winlator_cmod_core_PatchElf_isChanged(JNIEnv *env, jobject thiz, jlong object_ptr) {
+Java_com_winlator_star_core_PatchElf_isChanged(JNIEnv *env, jobject thiz, jlong object_ptr) {
     // TODO: implement isChanged()
 }
 extern "C"
 JNIEXPORT jstring JNICALL
-Java_com_winlator_cmod_core_PatchElf_getInterpreter(JNIEnv *env, jobject thiz, jlong object_ptr) {
+Java_com_winlator_star_core_PatchElf_getInterpreter(JNIEnv *env, jobject thiz, jlong object_ptr) {
     // TODO: implement getInterpreter()
 }
 extern "C"
 JNIEXPORT jboolean JNICALL
-Java_com_winlator_cmod_core_PatchElf_setInterpreter(JNIEnv *env, jobject thiz, jlong object_ptr,
+Java_com_winlator_star_core_PatchElf_setInterpreter(JNIEnv *env, jobject thiz, jlong object_ptr,
                                                jstring interpreter) {
     // TODO: implement setInterpreter()
 }
 extern "C"
 JNIEXPORT jstring JNICALL
-Java_com_winlator_cmod_core_PatchElf_getOsAbi(JNIEnv *env, jobject thiz, jlong object_ptr) {
+Java_com_winlator_star_core_PatchElf_getOsAbi(JNIEnv *env, jobject thiz, jlong object_ptr) {
     // TODO: implement getOsAbi()
 }
 extern "C"
 JNIEXPORT jboolean JNICALL
-Java_com_winlator_cmod_core_PatchElf_replaceOsAbi(JNIEnv *env, jobject thiz, jlong object_ptr,
+Java_com_winlator_star_core_PatchElf_replaceOsAbi(JNIEnv *env, jobject thiz, jlong object_ptr,
                                              jstring os_abi) {
     // TODO: implement replaceOsAbi()
 }
 extern "C"
 JNIEXPORT jstring JNICALL
-Java_com_winlator_cmod_core_PatchElf_getSoName(JNIEnv *env, jobject thiz, jlong object_ptr) {
+Java_com_winlator_star_core_PatchElf_getSoName(JNIEnv *env, jobject thiz, jlong object_ptr) {
     // TODO: implement getSoName()
 }
 extern "C"
 JNIEXPORT jboolean JNICALL
-Java_com_winlator_cmod_core_PatchElf_replaceSoName(JNIEnv *env, jobject thiz, jlong object_ptr,
+Java_com_winlator_star_core_PatchElf_replaceSoName(JNIEnv *env, jobject thiz, jlong object_ptr,
                                               jstring so_name) {
     // TODO: implement replaceSoName()
 }
 extern "C"
 JNIEXPORT jobjectArray JNICALL
-Java_com_winlator_cmod_core_PatchElf_getRPath(JNIEnv *env, jobject thiz, jlong object_ptr) {
+Java_com_winlator_star_core_PatchElf_getRPath(JNIEnv *env, jobject thiz, jlong object_ptr) {
     // TODO: implement getRPath()
 }
 extern "C"
 JNIEXPORT jboolean JNICALL
-Java_com_winlator_cmod_core_PatchElf_addRPath(JNIEnv *env, jobject thiz, jlong object_ptr,
+Java_com_winlator_star_core_PatchElf_addRPath(JNIEnv *env, jobject thiz, jlong object_ptr,
                                          jstring rpath) {
     // TODO: implement addRPath()
 }
 extern "C"
 JNIEXPORT jboolean JNICALL
-Java_com_winlator_cmod_core_PatchElf_removeRPath(JNIEnv *env, jobject thiz, jlong object_ptr,
+Java_com_winlator_star_core_PatchElf_removeRPath(JNIEnv *env, jobject thiz, jlong object_ptr,
                                             jstring rpath) {
     // TODO: implement removeRPath()
 }
 extern "C"
 JNIEXPORT jobjectArray JNICALL
-Java_com_winlator_cmod_core_PatchElf_getNeeded(JNIEnv *env, jobject thiz, jlong object_ptr) {
+Java_com_winlator_star_core_PatchElf_getNeeded(JNIEnv *env, jobject thiz, jlong object_ptr) {
     // TODO: implement getNeeded()
 }
 extern "C"
 JNIEXPORT jboolean JNICALL
-Java_com_winlator_cmod_core_PatchElf_addNeeded(JNIEnv *env, jobject thiz, jlong object_ptr,
+Java_com_winlator_star_core_PatchElf_addNeeded(JNIEnv *env, jobject thiz, jlong object_ptr,
                                           jstring needed) {
     // TODO: implement addNeeded()
 }
 extern "C"
 JNIEXPORT jboolean JNICALL
-Java_com_winlator_cmod_core_PatchElf_removeNeeded(JNIEnv *env, jobject thiz, jlong object_ptr,
+Java_com_winlator_star_core_PatchElf_removeNeeded(JNIEnv *env, jobject thiz, jlong object_ptr,
                                              jstring needed) {
     // TODO: implement removeNeeded()
 }

--- a/app/src/main/cpp/winlator/sysvshared_memory.c
+++ b/app/src/main/cpp/winlator/sysvshared_memory.c
@@ -47,7 +47,7 @@ static int memfd_create(const char *name, unsigned int flags) {
 }
 
 JNIEXPORT jint JNICALL
-Java_com_winlator_cmod_sysvshm_SysVSharedMemory_ashmemCreateRegion(JNIEnv *env, jobject obj, jint index,
+Java_com_winlator_star_sysvshm_SysVSharedMemory_ashmemCreateRegion(JNIEnv *env, jobject obj, jint index,
                                                               jlong size) {
     char name[32];
     sprintf(name, "sysvshm-%d", index);
@@ -55,21 +55,21 @@ Java_com_winlator_cmod_sysvshm_SysVSharedMemory_ashmemCreateRegion(JNIEnv *env, 
 }
 
 JNIEXPORT jobject JNICALL
-Java_com_winlator_cmod_sysvshm_SysVSharedMemory_mapSHMSegment(JNIEnv *env, jobject obj, jint fd, jlong size, jint offset, jboolean readonly) {
+Java_com_winlator_star_sysvshm_SysVSharedMemory_mapSHMSegment(JNIEnv *env, jobject obj, jint fd, jlong size, jint offset, jboolean readonly) {
     char *data = mmap(NULL, size, readonly ? PROT_READ : PROT_WRITE | PROT_READ, MAP_SHARED, fd, offset);
     if (data == MAP_FAILED) return NULL;
     return (*env)->NewDirectByteBuffer(env, data, size);
 }
 
 JNIEXPORT void JNICALL
-Java_com_winlator_cmod_sysvshm_SysVSharedMemory_unmapSHMSegment(JNIEnv *env, jobject obj, jobject data,
+Java_com_winlator_star_sysvshm_SysVSharedMemory_unmapSHMSegment(JNIEnv *env, jobject obj, jobject data,
                                                            jlong size) {
     char *dataAddr = (*env)->GetDirectBufferAddress(env, data);
     munmap(dataAddr, size);
 }
 
 JNIEXPORT jint JNICALL
-Java_com_winlator_cmod_sysvshm_SysVSharedMemory_createMemoryFd(JNIEnv *env, jclass obj, jstring name,
+Java_com_winlator_star_sysvshm_SysVSharedMemory_createMemoryFd(JNIEnv *env, jclass obj, jstring name,
                                                           jint size) {
     const char *namePtr = (*env)->GetStringUTFChars(env, name, 0);
 

--- a/app/src/main/cpp/winlator/vulkan.c
+++ b/app/src/main/cpp/winlator/vulkan.c
@@ -9,6 +9,8 @@
 #include <string.h>
 #include <fcntl.h>
 #include <android/api-level.h>
+#include <signal.h>
+#include <setjmp.h>
 #include "../adrenotools/include/adrenotools/driver.h"
 
 #define LOG_TAG "System.out"
@@ -22,6 +24,20 @@ PFN_vkEnumeratePhysicalDevices enumeratePhysicalDevices;
 PFN_vkDestroyInstance destroyInstance;
 
 static void *vulkan_handle = NULL;
+
+static sigjmp_buf sigill_jmp_buf;
+static struct sigaction saved_sigill_action;
+
+static void sigill_handler(int sig) {
+    siglongjmp(sigill_jmp_buf, 1);
+}
+
+static void cleanup_vulkan() {
+    if (vulkan_handle) {
+        dlclose(vulkan_handle);
+        vulkan_handle = NULL;
+    }
+}
 
 
 static char *get_native_library_dir(JNIEnv *env, jobject context) {
@@ -189,131 +205,200 @@ static VkResult enumerate_physical_devices() {
 
 JNIEXPORT jstring JNICALL
 Java_com_winlator_star_core_GPUInformation_getVulkanVersion(JNIEnv *env, jclass obj, jstring driverName, jobject context) {
-    VkPhysicalDeviceProperties props = {};
-    char *driverVersion;
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = sigill_handler;
+    sigemptyset(&sa.sa_mask);
+    sigaction(SIGILL, &sa, &saved_sigill_action);
 
-    if  (create_instance(driverName, env, context) != VK_SUCCESS) {
-        printf("Failed to create instance");
-        return (*env)->NewStringUTF(env, "Unknown");
+    if (sigsetjmp(sigill_jmp_buf, 1) == 0) {
+        VkPhysicalDeviceProperties props = {};
+        char *driverVersion;
+
+        if (create_instance(driverName, env, context) != VK_SUCCESS) {
+            printf("Failed to create instance");
+            sigaction(SIGILL, &saved_sigill_action, NULL);
+            cleanup_vulkan();
+            return (*env)->NewStringUTF(env, "Unknown");
+        }
+
+        if (enumerate_physical_devices() != VK_SUCCESS) {
+            printf("Failed to query physical devices");
+            sigaction(SIGILL, &saved_sigill_action, NULL);
+            cleanup_vulkan();
+            return (*env)->NewStringUTF(env, "Unknown");
+        }
+
+        getPhysicalDeviceProperties(physicalDevice, &props);
+        uint32_t api_version_major = VK_VERSION_MAJOR(props.apiVersion);
+        uint32_t api_version_minor = VK_VERSION_MINOR(props.apiVersion);
+        uint32_t api_version_patch = VK_VERSION_PATCH(props.apiVersion);
+        asprintf(&driverVersion, "%d.%d.%d", api_version_major, api_version_minor, api_version_patch);
+
+        destroyInstance(instance, NULL);
+
+        sigaction(SIGILL, &saved_sigill_action, NULL);
+        cleanup_vulkan();
+        return (*env)->NewStringUTF(env, driverVersion);
     }
 
-    if (enumerate_physical_devices() != VK_SUCCESS) {
-        printf("Failed to query physical devices");
-        return (*env)->NewStringUTF(env, "Unknown");
-    }
-
-    getPhysicalDeviceProperties(physicalDevice, &props);
-    uint32_t api_version_major = VK_VERSION_MAJOR(props.apiVersion);
-    uint32_t api_version_minor = VK_VERSION_MINOR(props.apiVersion);
-    uint32_t api_version_patch = VK_VERSION_PATCH(props.apiVersion);
-    asprintf(&driverVersion, "%d.%d.%d", api_version_major, api_version_minor, api_version_patch);
-
-    destroyInstance(instance, NULL);
-
-    if (vulkan_handle)
-        dlclose(vulkan_handle);
-
-    return (*env)->NewStringUTF(env, driverVersion);
+    printf("SIGILL caught: driver incompatible");
+    sigaction(SIGILL, &saved_sigill_action, NULL);
+    cleanup_vulkan();
+    return (*env)->NewStringUTF(env, "Unknown");
 }
 
 JNIEXPORT jint JNICALL
 Java_com_winlator_star_core_GPUInformation_getVendorID(JNIEnv *env, jclass obj, jstring driverName, jobject context) {
-    VkPhysicalDeviceProperties props = {};
-    uint32_t vendorID;
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = sigill_handler;
+    sigemptyset(&sa.sa_mask);
+    sigaction(SIGILL, &sa, &saved_sigill_action);
 
-    if  (create_instance(driverName, env, context) != VK_SUCCESS) {
-        printf("Failed to create instance");
-        return 0;
+    if (sigsetjmp(sigill_jmp_buf, 1) == 0) {
+        VkPhysicalDeviceProperties props = {};
+        uint32_t vendorID;
+
+        if (create_instance(driverName, env, context) != VK_SUCCESS) {
+            printf("Failed to create instance");
+            sigaction(SIGILL, &saved_sigill_action, NULL);
+            cleanup_vulkan();
+            return 0;
+        }
+
+        if (enumerate_physical_devices() != VK_SUCCESS) {
+            printf("Failed to query physical devices");
+            sigaction(SIGILL, &saved_sigill_action, NULL);
+            cleanup_vulkan();
+            return 0;
+        }
+
+        getPhysicalDeviceProperties(physicalDevice, &props);
+        vendorID = props.vendorID;
+
+        destroyInstance(instance, NULL);
+
+        sigaction(SIGILL, &saved_sigill_action, NULL);
+        cleanup_vulkan();
+        return vendorID;
     }
 
-    if (enumerate_physical_devices() != VK_SUCCESS) {
-        printf("Failed to query physical devices");
-        return 0;
-    }
-
-    getPhysicalDeviceProperties(physicalDevice, &props);
-    vendorID = props.vendorID;
-
-    destroyInstance(instance, NULL);
-
-    if (vulkan_handle)
-        dlclose(vulkan_handle);
-
-    return vendorID;
+    printf("SIGILL caught: driver incompatible");
+    sigaction(SIGILL, &saved_sigill_action, NULL);
+    cleanup_vulkan();
+    return 0;
 }
 
 
 JNIEXPORT jstring JNICALL
 Java_com_winlator_star_core_GPUInformation_getRenderer(JNIEnv *env, jclass obj, jstring driverName, jobject context) {
-    VkPhysicalDeviceProperties props = {};
-    char *renderer;
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = sigill_handler;
+    sigemptyset(&sa.sa_mask);
+    sigaction(SIGILL, &sa, &saved_sigill_action);
 
+    if (sigsetjmp(sigill_jmp_buf, 1) == 0) {
+        VkPhysicalDeviceProperties props = {};
+        char *renderer;
 
-    if  (create_instance(driverName, env, context) != VK_SUCCESS) {
-        printf("Failed to create instance");
-        return (*env)->NewStringUTF(env, "Unknown");
+        if (create_instance(driverName, env, context) != VK_SUCCESS) {
+            printf("Failed to create instance");
+            sigaction(SIGILL, &saved_sigill_action, NULL);
+            cleanup_vulkan();
+            return (*env)->NewStringUTF(env, "Unknown");
+        }
+
+        if (enumerate_physical_devices() != VK_SUCCESS) {
+            printf("Failed to query physical devices");
+            sigaction(SIGILL, &saved_sigill_action, NULL);
+            cleanup_vulkan();
+            return (*env)->NewStringUTF(env, "Unknown");
+        }
+
+        getPhysicalDeviceProperties(physicalDevice, &props);
+        asprintf(&renderer, "%s", props.deviceName);
+
+        destroyInstance(instance, NULL);
+
+        sigaction(SIGILL, &saved_sigill_action, NULL);
+        cleanup_vulkan();
+        return (*env)->NewStringUTF(env, renderer);
     }
 
-    if (enumerate_physical_devices() != VK_SUCCESS) {
-        printf("Failed to query physical devices");
-        return (*env)->NewStringUTF(env, "Unknown");
-    }
-
-    getPhysicalDeviceProperties(physicalDevice, &props);
-    asprintf(&renderer, "%s", props.deviceName);
-
-    destroyInstance(instance, NULL);
-
-    if (vulkan_handle)
-        dlclose(vulkan_handle);
-
-    return (*env)->NewStringUTF(env, renderer);
+    printf("SIGILL caught: driver incompatible");
+    sigaction(SIGILL, &saved_sigill_action, NULL);
+    cleanup_vulkan();
+    return (*env)->NewStringUTF(env, "Unknown");
 }
 
 JNIEXPORT jobjectArray JNICALL
 Java_com_winlator_star_core_GPUInformation_enumerateExtensions(JNIEnv *env, jclass obj, jstring driverName, jobject context) {
-    jobjectArray extensions;
-    VkResult result;
-    uint32_t extensionCount;
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = sigill_handler;
+    sigemptyset(&sa.sa_mask);
+    sigaction(SIGILL, &sa, &saved_sigill_action);
 
-    if  (create_instance(driverName, env, context) != VK_SUCCESS) {
-        printf("Failed to create instance");
-        return (*env)->NewObjectArray(env, 0, (*env)->FindClass(env, "java/lang/String"), NULL);
+    if (sigsetjmp(sigill_jmp_buf, 1) == 0) {
+        jobjectArray extensions;
+        VkResult result;
+        uint32_t extensionCount;
+
+        if (create_instance(driverName, env, context) != VK_SUCCESS) {
+            printf("Failed to create instance");
+            sigaction(SIGILL, &saved_sigill_action, NULL);
+            cleanup_vulkan();
+            return (*env)->NewObjectArray(env, 0, (*env)->FindClass(env, "java/lang/String"), NULL);
+        }
+
+        if (enumerate_physical_devices() != VK_SUCCESS) {
+            printf("Failed to query physical devices");
+            sigaction(SIGILL, &saved_sigill_action, NULL);
+            cleanup_vulkan();
+            return (*env)->NewObjectArray(env, 0, (*env)->FindClass(env, "java/lang/String"), NULL);
+        }
+
+        result = enumerateDeviceExtensionProperties(physicalDevice, NULL, &extensionCount, NULL);
+
+        if (result != VK_SUCCESS || extensionCount < 1) {
+            printf("Failed to query extension count");
+            sigaction(SIGILL, &saved_sigill_action, NULL);
+            cleanup_vulkan();
+            return (*env)->NewObjectArray(env, 0, (*env)->FindClass(env, "java/lang/String"), NULL);
+        }
+
+        VkExtensionProperties *extensionProperties = malloc(sizeof(VkExtensionProperties) * extensionCount);
+        enumerateDeviceExtensionProperties(physicalDevice, NULL, &extensionCount,
+                                           extensionProperties);
+
+        if (result != VK_SUCCESS) {
+            printf("Failed to query extensions");
+            sigaction(SIGILL, &saved_sigill_action, NULL);
+            cleanup_vulkan();
+            if (extensionProperties) free(extensionProperties);
+            return (*env)->NewObjectArray(env, 0, (*env)->FindClass(env, "java/lang/String"), NULL);
+        }
+
+        extensions = (jobjectArray) (*env)->NewObjectArray(env, extensionCount,
+                                                           (*env)->FindClass(env, "java/lang/String"),
+                                                           NULL);
+        for (int i = 0; i < extensionCount; i++) {
+            (*env)->SetObjectArrayElement(env, extensions, i,
+                                          (*env)->NewStringUTF(env, extensionProperties[i].extensionName));
+        }
+
+        if (extensionProperties) free(extensionProperties);
+        destroyInstance(instance, NULL);
+
+        sigaction(SIGILL, &saved_sigill_action, NULL);
+        cleanup_vulkan();
+        return extensions;
     }
 
-    if (enumerate_physical_devices() != VK_SUCCESS) {
-        printf("Failed to query physical devices");
-        return (*env)->NewObjectArray(env, 0, (*env)->FindClass(env, "java/lang/String"), NULL);
-    }
-
-    result = enumerateDeviceExtensionProperties(physicalDevice, NULL, &extensionCount, NULL);
-
-    if (result != VK_SUCCESS || extensionCount < 1) {
-        printf("Failed to query extension count");
-        return (*env)->NewObjectArray(env, 0, (*env)->FindClass(env, "java/lang/String"), NULL);
-    }    
-    
-    VkExtensionProperties *extensionProperties = malloc(sizeof(VkExtensionProperties) * extensionCount);
-    enumerateDeviceExtensionProperties(physicalDevice, NULL, &extensionCount,
-                                       extensionProperties);
-
-    if (result != VK_SUCCESS) {
-        printf("Failed to query extensions");
-        return (*env)->NewObjectArray(env, 0, (*env)->FindClass(env, "java/lang/String"), NULL);
-    }
-
-    extensions = (jobjectArray) (*env)->NewObjectArray(env, extensionCount,
-                                                       (*env)->FindClass(env, "java/lang/String"),
-                                                       NULL);
-    for (int i = 0; i < extensionCount; i++) {
-        (*env)->SetObjectArrayElement(env, extensions, i,
-                                      (*env)->NewStringUTF(env, extensionProperties[i].extensionName));
-    }
-
-    destroyInstance(instance, NULL);
-
-    if (vulkan_handle)
-        dlclose(vulkan_handle);
-
-    return extensions;
+    printf("SIGILL caught: driver incompatible");
+    sigaction(SIGILL, &saved_sigill_action, NULL);
+    cleanup_vulkan();
+    return (*env)->NewObjectArray(env, 0, (*env)->FindClass(env, "java/lang/String"), NULL);
 }

--- a/app/src/main/cpp/winlator/vulkan.c
+++ b/app/src/main/cpp/winlator/vulkan.c
@@ -28,7 +28,7 @@ static char *get_native_library_dir(JNIEnv *env, jobject context) {
     char *native_libdir;
 
     if (context != NULL) {
-        jclass class_ = (*env)->FindClass(env,"com/winlator/cmod/core/AppUtils");
+        jclass class_ = (*env)->FindClass(env,"com/winlator/star/core/AppUtils");
         jmethodID getNativeLibraryDir = (*env)->GetStaticMethodID(env, class_, "getNativeLibDir",
                                                                "(Landroid/content/Context;)Ljava/lang/String;");
         jstring nativeLibDir = (jstring)(*env)->CallStaticObjectMethod(env, class_,
@@ -65,7 +65,7 @@ static char *get_driver_path(JNIEnv *env, jobject context, const char *driver_na
 static char *get_library_name(JNIEnv *env, jobject context, const char *driver_name) {
     char *library_name;
 
-    jclass adrenotoolsManager = (*env)->FindClass(env, "com/winlator/cmod/contents/AdrenotoolsManager");
+    jclass adrenotoolsManager = (*env)->FindClass(env, "com/winlator/star/contents/AdrenotoolsManager");
     jmethodID constructor = (*env)->GetMethodID(env, adrenotoolsManager, "<init>", "(Landroid/content/Context;)V");
     jobject  adrenotoolsManagerObj = (*env)->NewObject(env, adrenotoolsManager, constructor, context);
     jmethodID getLibraryName = (*env)->GetMethodID(env, adrenotoolsManager, "getLibraryName","(Ljava/lang/String;)Ljava/lang/String;");
@@ -188,7 +188,7 @@ static VkResult enumerate_physical_devices() {
 }
 
 JNIEXPORT jstring JNICALL
-Java_com_winlator_cmod_core_GPUInformation_getVulkanVersion(JNIEnv *env, jclass obj, jstring driverName, jobject context) {
+Java_com_winlator_star_core_GPUInformation_getVulkanVersion(JNIEnv *env, jclass obj, jstring driverName, jobject context) {
     VkPhysicalDeviceProperties props = {};
     char *driverVersion;
 
@@ -217,7 +217,7 @@ Java_com_winlator_cmod_core_GPUInformation_getVulkanVersion(JNIEnv *env, jclass 
 }
 
 JNIEXPORT jint JNICALL
-Java_com_winlator_cmod_core_GPUInformation_getVendorID(JNIEnv *env, jclass obj, jstring driverName, jobject context) {
+Java_com_winlator_star_core_GPUInformation_getVendorID(JNIEnv *env, jclass obj, jstring driverName, jobject context) {
     VkPhysicalDeviceProperties props = {};
     uint32_t vendorID;
 
@@ -244,7 +244,7 @@ Java_com_winlator_cmod_core_GPUInformation_getVendorID(JNIEnv *env, jclass obj, 
 
 
 JNIEXPORT jstring JNICALL
-Java_com_winlator_cmod_core_GPUInformation_getRenderer(JNIEnv *env, jclass obj, jstring driverName, jobject context) {
+Java_com_winlator_star_core_GPUInformation_getRenderer(JNIEnv *env, jclass obj, jstring driverName, jobject context) {
     VkPhysicalDeviceProperties props = {};
     char *renderer;
 
@@ -271,7 +271,7 @@ Java_com_winlator_cmod_core_GPUInformation_getRenderer(JNIEnv *env, jclass obj, 
 }
 
 JNIEXPORT jobjectArray JNICALL
-Java_com_winlator_cmod_core_GPUInformation_enumerateExtensions(JNIEnv *env, jclass obj, jstring driverName, jobject context) {
+Java_com_winlator_star_core_GPUInformation_enumerateExtensions(JNIEnv *env, jclass obj, jstring driverName, jobject context) {
     jobjectArray extensions;
     VkResult result;
     uint32_t extensionCount;

--- a/app/src/main/cpp/winlator/xconnector_epoll.c
+++ b/app/src/main/cpp/winlator/xconnector_epoll.c
@@ -18,7 +18,7 @@
 struct epoll_event events[MAX_EVENTS];
 
 JNIEXPORT jint JNICALL
-Java_com_winlator_cmod_xconnector_XConnectorEpoll_createAFUnixSocket(JNIEnv *env, jobject obj,
+Java_com_winlator_star_xconnector_XConnectorEpoll_createAFUnixSocket(JNIEnv *env, jobject obj,
                                                                 jstring path) {
     int fd = socket(AF_UNIX, SOCK_STREAM, 0);
     if (fd < 0) return -1;
@@ -45,17 +45,17 @@ Java_com_winlator_cmod_xconnector_XConnectorEpoll_createAFUnixSocket(JNIEnv *env
 }
 
 JNIEXPORT jint JNICALL
-Java_com_winlator_cmod_xconnector_XConnectorEpoll_createEpollFd(JNIEnv *env, jobject obj) {
+Java_com_winlator_star_xconnector_XConnectorEpoll_createEpollFd(JNIEnv *env, jobject obj) {
     return epoll_create(MAX_EVENTS);
 }
 
 JNIEXPORT void JNICALL
-Java_com_winlator_cmod_xconnector_XConnectorEpoll_closeFd(JNIEnv *env, jobject obj, jint fd) {
+Java_com_winlator_star_xconnector_XConnectorEpoll_closeFd(JNIEnv *env, jobject obj, jint fd) {
     close(fd);
 }
 
 JNIEXPORT jboolean JNICALL
-Java_com_winlator_cmod_xconnector_XConnectorEpoll_doEpollIndefinitely(JNIEnv *env, jobject obj,
+Java_com_winlator_star_xconnector_XConnectorEpoll_doEpollIndefinitely(JNIEnv *env, jobject obj,
                                                                  jint epollFd, jint serverFd,
                                                                  jboolean addClientToEpoll) {
     jclass cls = (*env)->GetObjectClass(env, obj);
@@ -88,7 +88,7 @@ Java_com_winlator_cmod_xconnector_XConnectorEpoll_doEpollIndefinitely(JNIEnv *en
 }
 
 JNIEXPORT jboolean JNICALL
-Java_com_winlator_cmod_xconnector_XConnectorEpoll_addFdToEpoll(JNIEnv *env, jobject obj,
+Java_com_winlator_star_xconnector_XConnectorEpoll_addFdToEpoll(JNIEnv *env, jobject obj,
                                                           jint epollFd,
                                                           jint fd) {
     struct epoll_event event;
@@ -99,32 +99,32 @@ Java_com_winlator_cmod_xconnector_XConnectorEpoll_addFdToEpoll(JNIEnv *env, jobj
 }
 
 JNIEXPORT void JNICALL
-Java_com_winlator_cmod_xconnector_XConnectorEpoll_removeFdFromEpoll(JNIEnv *env, jobject obj,
+Java_com_winlator_star_xconnector_XConnectorEpoll_removeFdFromEpoll(JNIEnv *env, jobject obj,
                                                                jint epollFd, jint fd) {
     epoll_ctl(epollFd, EPOLL_CTL_DEL, fd, NULL);
 }
 
 JNIEXPORT jint JNICALL
-Java_com_winlator_cmod_xconnector_ClientSocket_read(JNIEnv *env, jobject obj, jint fd, jobject data,
+Java_com_winlator_star_xconnector_ClientSocket_read(JNIEnv *env, jobject obj, jint fd, jobject data,
                                                jint offset, jint length) {
     char *dataAddr = (*env)->GetDirectBufferAddress(env, data);
     return read(fd, dataAddr + offset, length);
 }
 
 JNIEXPORT jint JNICALL
-Java_com_winlator_cmod_xconnector_ClientSocket_write(JNIEnv *env, jobject obj, jint fd, jobject data,
+Java_com_winlator_star_xconnector_ClientSocket_write(JNIEnv *env, jobject obj, jint fd, jobject data,
                                                 jint length) {
     char *dataAddr = (*env)->GetDirectBufferAddress(env, data);
     return write(fd, dataAddr, length);
 }
 
 JNIEXPORT jint JNICALL
-Java_com_winlator_cmod_xconnector_XConnectorEpoll_createEventFd(JNIEnv *env, jobject obj) {
+Java_com_winlator_star_xconnector_XConnectorEpoll_createEventFd(JNIEnv *env, jobject obj) {
     return eventfd(0, EFD_NONBLOCK);
 }
 
 JNIEXPORT jint JNICALL
-Java_com_winlator_cmod_xconnector_ClientSocket_recvAncillaryMsg(JNIEnv *env, jobject obj, jint clientFd, jobject data,
+Java_com_winlator_star_xconnector_ClientSocket_recvAncillaryMsg(JNIEnv *env, jobject obj, jint clientFd, jobject data,
                                                            jint offset, jint length) {
     char *dataAddr = (*env)->GetDirectBufferAddress(env, data);
 
@@ -165,7 +165,7 @@ Java_com_winlator_cmod_xconnector_ClientSocket_recvAncillaryMsg(JNIEnv *env, job
 }
 
 JNIEXPORT jint JNICALL
-Java_com_winlator_cmod_xconnector_ClientSocket_sendAncillaryMsg(JNIEnv *env, jobject obj, jint clientFd,
+Java_com_winlator_star_xconnector_ClientSocket_sendAncillaryMsg(JNIEnv *env, jobject obj, jint clientFd,
                                                            jobject data, jint length, jint ancillaryFd) {
     char *dataAddr = (*env)->GetDirectBufferAddress(env, data);
 
@@ -195,7 +195,7 @@ Java_com_winlator_cmod_xconnector_ClientSocket_sendAncillaryMsg(JNIEnv *env, job
 }
 
 JNIEXPORT jboolean JNICALL
-Java_com_winlator_cmod_xconnector_XConnectorEpoll_waitForSocketRead(JNIEnv *env, jobject obj, jint clientFd, jint shutdownFd) {
+Java_com_winlator_star_xconnector_XConnectorEpoll_waitForSocketRead(JNIEnv *env, jobject obj, jint clientFd, jint shutdownFd) {
     struct pollfd pfds[2];
     pfds[0].fd = clientFd;
     pfds[0].events = POLLIN;
@@ -215,7 +215,7 @@ Java_com_winlator_cmod_xconnector_XConnectorEpoll_waitForSocketRead(JNIEnv *env,
 }
 
 JNIEXPORT jintArray JNICALL
-Java_com_winlator_cmod_xconnector_XConnectorEpoll_pollEpollEvents(JNIEnv *env, jobject obj,
+Java_com_winlator_star_xconnector_XConnectorEpoll_pollEpollEvents(JNIEnv *env, jobject obj,
                                                              jint epollFd, jint maxEvents) {
     struct epoll_event events[maxEvents];
     int numFds = epoll_wait(epollFd, events, maxEvents, -1); // Wait indefinitely

--- a/app/src/main/cpp/xr/main.c
+++ b/app/src/main/cpp/xr/main.c
@@ -31,7 +31,7 @@ void OXRCheckErrors(XrResult result, const char* file, int line) {
 }
 #endif
 
-JNIEXPORT void JNICALL Java_com_winlator_XrActivity_init(JNIEnv *env, jobject obj) {
+JNIEXPORT void JNICALL Java_com_winlator_star_XrActivity_init(JNIEnv *env, jobject obj) {
 
     // Do not allow second initialization
     if (xr_initialized) {
@@ -62,24 +62,24 @@ JNIEXPORT void JNICALL Java_com_winlator_XrActivity_init(JNIEnv *env, jobject ob
     ALOGV("Init called");
 }
 
-JNIEXPORT void JNICALL Java_com_winlator_XrActivity_bindFramebuffer(JNIEnv *env, jobject obj) {
+JNIEXPORT void JNICALL Java_com_winlator_star_XrActivity_bindFramebuffer(JNIEnv *env, jobject obj) {
     if (xr_initialized) {
         XrRendererBindFramebuffer(&xr_module_renderer);
     }
 }
 
-JNIEXPORT jint JNICALL Java_com_winlator_XrActivity_getWidth(JNIEnv *env, jobject obj) {
+JNIEXPORT jint JNICALL Java_com_winlator_star_XrActivity_getWidth(JNIEnv *env, jobject obj) {
     int w, h;
     XrRendererGetResolution(&xr_module_engine, &xr_module_renderer, &w, &h);
     return w;
 }
-JNIEXPORT jint JNICALL Java_com_winlator_XrActivity_getHeight(JNIEnv *env, jobject obj) {
+JNIEXPORT jint JNICALL Java_com_winlator_star_XrActivity_getHeight(JNIEnv *env, jobject obj) {
     int w, h;
     XrRendererGetResolution(&xr_module_engine, &xr_module_renderer, &w, &h);
     return h;
 }
 
-JNIEXPORT jboolean JNICALL Java_com_winlator_XrActivity_beginFrame(JNIEnv *env, jobject obj, jboolean immersive, jboolean sbs) {
+JNIEXPORT jboolean JNICALL Java_com_winlator_star_XrActivity_beginFrame(JNIEnv *env, jobject obj, jboolean immersive, jboolean sbs) {
     if (XrRendererInitFrame(&xr_module_engine, &xr_module_renderer)) {
 
         // Set render canvas
@@ -107,12 +107,12 @@ JNIEXPORT jboolean JNICALL Java_com_winlator_XrActivity_beginFrame(JNIEnv *env, 
     return false;
 }
 
-JNIEXPORT void JNICALL Java_com_winlator_XrActivity_endFrame(JNIEnv *env, jobject obj) {
+JNIEXPORT void JNICALL Java_com_winlator_star_XrActivity_endFrame(JNIEnv *env, jobject obj) {
     XrRendererEndFrame(&xr_module_renderer);
     XrRendererFinishFrame(&xr_module_engine, &xr_module_renderer);
 }
 
-JNIEXPORT jfloatArray JNICALL Java_com_winlator_XrActivity_getAxes(JNIEnv *env, jobject obj) {
+JNIEXPORT jfloatArray JNICALL Java_com_winlator_star_XrActivity_getAxes(JNIEnv *env, jobject obj) {
     XrPosef lPose = XrInputGetPose(&xr_module_input, 0);
     XrPosef rPose = XrInputGetPose(&xr_module_input, 1);
     XrVector2f lThumbstick = XrInputGetJoystickState(&xr_module_input, 0);
@@ -155,7 +155,7 @@ JNIEXPORT jfloatArray JNICALL Java_com_winlator_XrActivity_getAxes(JNIEnv *env, 
     return output;
 }
 
-JNIEXPORT jbooleanArray JNICALL Java_com_winlator_XrActivity_getButtons(JNIEnv *env, jobject obj) {
+JNIEXPORT jbooleanArray JNICALL Java_com_winlator_star_XrActivity_getButtons(JNIEnv *env, jobject obj) {
     uint32_t l = XrInputGetButtonState(&xr_module_input, 0);
     uint32_t r = XrInputGetButtonState(&xr_module_input, 1);
 

--- a/app/src/main/java/com/winlator/star/ui/screens/ContainerDetailScreen.kt
+++ b/app/src/main/java/com/winlator/star/ui/screens/ContainerDetailScreen.kt
@@ -990,9 +990,10 @@ internal fun GraphicsDriverConfigDialog(
         (cfg["blacklistedExtensions"] ?: "").split(",").filter { it.isNotEmpty() }.toSet()
     }
     var blacklisted   by remember { mutableStateOf(initialBlacklist) }
+    var showAllDrivers by remember { mutableStateOf(false) }
     var showExtPicker by remember { mutableStateOf(false) }
 
-    LaunchedEffect(Unit) {
+    LaunchedEffect(showAllDrivers) {
         val atVersions = withContext(Dispatchers.IO) {
             AdrenotoolsManager(context).enumarateInstalledDrivers()
         }
@@ -1009,7 +1010,10 @@ internal fun GraphicsDriverConfigDialog(
         // concurrent AdrenoTools hook invocations that cause SIGSEGV.
         val wrapperVersions = context.resources
             .getStringArray(R.array.wrapper_graphics_driver_version_entries)
-            .filter { GPUInformation.isDriverSupported(it, context) }
+            .let { arr ->
+                if (showAllDrivers) arr.toList()
+                else arr.filter { GPUInformation.isDriverSupported(it, context) }
+            }
 
         driverVersions = wrapperVersions + atVersions
         gpuNames = gpuList
@@ -1052,6 +1056,11 @@ internal fun GraphicsDriverConfigDialog(
                 LabeledDropdown(stringResource(R.string.graphics_driver_vulkan_version), vulkanVersions, vulkanVersion, { vulkanVersion = it })
                 Spacer(Modifier.height(8.dp))
                 LabeledDropdown(stringResource(R.string.graphics_driver_version), driverVersions, version, { version = it })
+                Spacer(Modifier.height(8.dp))
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Checkbox(checked = showAllDrivers, onCheckedChange = { showAllDrivers = it })
+                    Text(stringResource(R.string.graphics_driver_show_incompatible))
+                }
                 Spacer(Modifier.height(8.dp))
                 OutlinedButton(
                     onClick = { showExtPicker = true },
@@ -1170,7 +1179,7 @@ internal fun DxvkConfigDialog(
     val allDxvkVersions = remember { mutableStateOf(listOf<String>()) }
     val vkd3dVersions   = remember { mutableStateOf(listOf<String>()) }
 
-    LaunchedEffect(Unit) {
+    LaunchedEffect(showAllDrivers) {
         withContext(Dispatchers.IO) {
             val cm = ContentsManager(context)
             cm.syncContents()
@@ -1280,7 +1289,7 @@ internal fun WineD3DConfigDialog(
     val videoMemEntries = remember { context.resources.getStringArray(R.array.video_memory_size_entries).toList() }
     var gpuNames      by remember { mutableStateOf(listOf<String>()) }
 
-    LaunchedEffect(Unit) {
+    LaunchedEffect(showAllDrivers) {
         withContext(Dispatchers.IO) {
             val names = WineD3DConfigDialog.loadGpuNames(context)
             withContext(Dispatchers.Main) { gpuNames = names }

--- a/app/src/main/java/com/winlator/star/ui/screens/ContainerDetailScreen.kt
+++ b/app/src/main/java/com/winlator/star/ui/screens/ContainerDetailScreen.kt
@@ -1179,7 +1179,7 @@ internal fun DxvkConfigDialog(
     val allDxvkVersions = remember { mutableStateOf(listOf<String>()) }
     val vkd3dVersions   = remember { mutableStateOf(listOf<String>()) }
 
-    LaunchedEffect(showAllDrivers) {
+    LaunchedEffect(Unit) {
         withContext(Dispatchers.IO) {
             val cm = ContentsManager(context)
             cm.syncContents()
@@ -1289,7 +1289,7 @@ internal fun WineD3DConfigDialog(
     val videoMemEntries = remember { context.resources.getStringArray(R.array.video_memory_size_entries).toList() }
     var gpuNames      by remember { mutableStateOf(listOf<String>()) }
 
-    LaunchedEffect(showAllDrivers) {
+    LaunchedEffect(Unit) {
         withContext(Dispatchers.IO) {
             val names = WineD3DConfigDialog.loadGpuNames(context)
             withContext(Dispatchers.Main) { gpuNames = names }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -670,6 +670,7 @@ E.g. <b>META</b> for <i>META key</i>, \n
     <string name="lsfg_gpu_arch_desc">Optimizes compute for your GPU. Auto detects from device info.</string>
     <string name="lsfg_close">Close</string>
 
+    <string name="graphics_driver_show_incompatible">Show incompatible drivers</string>
 </resources>
 
 


### PR DESCRIPTION
## Summary

Full LSFG settings with per-GPU presets + all JNI `UnsatisfiedLinkError` fixes + SIGILL handler for Turnip crashes + Show incompatible drivers toggle.

### Fixes
- **JNI package rename**: `com_winlator_cmod` → `com_winlator_star` across **all 10 C/C++ files** (51 function entries) — resolves all `UnsatisfiedLinkError` crashes on container launch
- **SIGILL signal handler** in `vulkan.c` — catches Turnip driver crashes on unsupported GPUs, gracefully returns `"Unknown"` instead of crashing
- **"Show incompatible drivers" toggle** in `GraphicsDriverConfigDialog` — default filtered/safe, toggle on to experiment with any Turnip version
- Wrapper gear NPE fix — null safety for `selectedDXWrapper`

### LSFG Settings
- LsfgSettingsScreen with per-GPU presets (Adreno/Mali/Auto)
- GPU Arch selector + Reset to GPU Defaults + Save as Defaults (persists + pushes to XServerDrawerState live)
- Drawer A (AppDrawer) = full settings, Drawer B (XServerDrawer) = bare settings only
- ContainerDetailScreen: toggle on/off only

### Files changed
app/src/main/cpp/winlator/*.c — 6 files
app/src/main/cpp/virglrenderer/server/*.c — 2 files
app/src/main/cpp/xr/main.c
app/src/main/java/com/winlator/star/ui/screens/*.kt — LsfgSettingsScreen, ContainerDetailScreen, XServerDrawer, AppNavGraph, AppDrawer, Screen
app/src/main/java/com/winlator/star/container/Container.java
app/src/main/res/values/strings.xml