### PR TITLE
feat(xserver): add launched_from_frontend intent extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Windows applications and games on Android.</h1>
 
 - **Upstream lineage:** Winlator → cmod → Bionic Nightly → star Bionic**
 
-## Frontends Workaround
-Sadly star doesnt work by itself on frontends, but you can check [this](https://github.com/star-emu/star/blob/marcescence/marcescence-frontends.md) workaround guide to make it work!
+## Frontend Support
+Frontends like ES-DE don't support star out of the box (yet), but they can be configured to launch games and exit cleanly. See the [frontend setup guide](https://github.com/star-emu/star/blob/marcescence/marcescence-frontends.md) for instructions.
 
 ---
 

--- a/app/src/main/java/com/winlator/star/XServerDisplayActivity.java
+++ b/app/src/main/java/com/winlator/star/XServerDisplayActivity.java
@@ -922,7 +922,12 @@ public class XServerDisplayActivity extends AppCompatActivity {
                     }
                 }
                 preloaderDialog.closeOnUiThread();
-                AppUtils.restartApplication(getApplicationContext());
+                if (getIntent().getBooleanExtra("launched_from_frontend", false)) {
+                    finishAndRemoveTask();
+                    Runtime.getRuntime().exit(0);
+                } else {
+                    AppUtils.restartApplication(getApplicationContext());
+                }
             }
         }, 1000);
     }

--- a/marcescence-frontends.md
+++ b/marcescence-frontends.md
@@ -1,35 +1,70 @@
-# ES-DE
-- Thanks to xabbu33 for the pull request and tutorial.
+# Frontend Setup Guide
 
-Use the correct am start command:
+Export your game shortcuts from Winlator as `.desktop` files and drop them into your frontend's library folder. Then configure the frontend to launch them with star using the instructions below.
 
-```am start \
-  -n com.winlator.star/com.winlator.star.XServerDisplayActivity \
-  -e shortcut_path {file.path} \
+---
+
+## General / ADB
+
+```sh
+adb shell am start \
+  -n com.winlator.star/.XServerDisplayActivity \
   --activity-clear-task \
-  --activity-clear-top
+  --activity-clear-top \
+  --ez launched_from_frontend true \
+  -e shortcut_path /storage/emulated/0/ROMs/windows/game.desktop
 ```
 
+> `--ez launched_from_frontend true` tells star to exit cleanly back to the frontend when the game closes, rather than restarting the star UI.
 
-For ES-DE, add this to your `custom_systems`/`es_find_rules.xml`:
-```<emulator name="WINLATOR-STAR">
+---
+
+## Daijishou
+
+Go to **Settings → Players → Add player** (or edit an existing one). Fill in **Player am start arguments**:
+
+```
+-n com.winlator.star/.XServerDisplayActivity
+--activity-clear-task
+--activity-clear-top
+--ez launched_from_frontend true
+-e shortcut_path {file.path}
+```
+
+Set **Player accepted filename regex** to:
+
+```
+^(.*)\.desktop$
+```
+
+---
+
+## ES-DE
+
+Add this to your `custom_systems/es_find_rules.xml`:
+
+```xml
+<emulator name="WINLATOR-STAR">
     <rule type="androidpackage">
         <entry>com.winlator.star/.XServerDisplayActivity</entry>
     </rule>
-</emulator> 
+</emulator>
 ```
 
-And in es_systems.xml:
-```
+And in `es_systems.xml`:
+
+```xml
 <system>
     <name>windows</name>
     <fullname>Microsoft Windows</fullname>
     <path>%ROMPATH%/windows</path>
     <extension>.desktop .DESKTOP</extension>
-    <command label="Winlator Star (Standalone)">%EMULATOR_WINLATOR-STAR% %ACTIVITY_CLEAR_TASK% %ACTIVITY_CLEAR_TOP% %EXTRA_shortcut_path%=%ROM%</command>
+    <command label="Winlator Star (Standalone)">%EMULATOR_WINLATOR-STAR% %ACTIVITY_CLEAR_TASK% %ACTIVITY_CLEAR_TOP% %EXTRABOOL_launched_from_frontend%=true %EXTRA_shortcut_path%=%ROM%</command>
     <platform>windows</platform>
     <theme>windows</theme>
-</system> 
+</system>
 ```
 
-Drop your exported .desktop shortcuts from Winlator into `ROMs/windows/` and they'll show up as games in ES-DE.
+---
+
+Thanks to xabbu33 for the pull request and tutorial.


### PR DESCRIPTION
## Summary

When `XServerDisplayActivity` is launched from an external frontend, the current `exit()` behaviour calls `AppUtils.restartApplication()`, which brings up Winlator's main UI instead of returning to the frontend.

This PR adds a `launched_from_frontend` boolean intent extra. When set to `true`, the activity calls `finishAndRemoveTask()` on exit (plus `Runtime.getRuntime().exit(0)` to ensure Wine/Box64/FEX native processes are fully killed), returning control cleanly to the calling frontend.

**Default is `false`** — home-screen shortcuts are completely unaffected.

## Usage

```sh
adb shell am start \
  -n com.winlator.star/.XServerDisplayActivity \
  --activity-clear-task \
  --activity-clear-top \
  --ez launched_from_frontend true \
  -e shortcut_path /storage/emulated/0/ROMs/windows/game.desktop
```

See `marcescence-frontends.md` for ES-DE and Daijishou setup instructions.

## Test plan

- [x] Launch via home-screen shortcut (`launched_from_frontend` not set) → exits to Winlator main UI as before
- [x] Launch with `launched_from_frontend=true` via ADB → exits cleanly, no Winlator UI flash
- [x] ES-DE → exits cleanly back to ES-DE
- [x] Daijishou → exits cleanly back to Daijishou